### PR TITLE
修改了 README 的两处小错

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ $ composer require leonis/easysms-notification-channel
     ```php
     'providers' => [
         // ...
-        Leonis\Notifications\EasySmsChannelServiceProvider::class,
+        Leonis\Notifications\EasySms\EasySmsChannelServiceProvider::class,
     ],
     ```
 
 2. 创建配置文件：
 
     ```shell
-    $ php artisan vendor:publish --provider="Leonis\Notifications\EasySmsChannelServiceProvider"
+    $ php artisan vendor:publish --provider="Leonis\Notifications\EasySms\EasySmsChannelServiceProvider"
     ```
     
 3. 修改应用根目录下的 config/easysms.php 中对应的参数即可。


### PR DESCRIPTION
将 `Leonis\Notifications\EasySmsChannelServiceProvider` 改为了 `Leonis\Notifications\EasySms\EasySmsChannelServiceProvider`

我在用的时候，发现后者才是正确的。